### PR TITLE
Main record file - fix settings for the v0.5.7

### DIFF
--- a/test_workspace/projects.yaml
+++ b/test_workspace/projects.yaml
@@ -1,7 +1,8 @@
 settings:
     # these are intentionally odd, since it's to make sure that
     # the Workspace class is recognising them correctly
-    paths:
-        definitions: ~/.notpg
-    generated_projects_folder: not_generated_projects
+    definitions_dir:
+        - ~/.notpg
+    generated_projects_folder:
+        - not_generated_projects
 


### PR DESCRIPTION
- follow the syntax for pgen yaml
- corrected definitions_dir name, might to look at this again as tools in settings were changed a bit to allow further expansion in settings:tools
